### PR TITLE
Reintroduce `sanitize_carriers` and `sanitize_location` (PyPSA-ASEAN)

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -17,6 +17,8 @@ This part of documentation collects descriptive release notes to capture the mai
 
 **Minor Changes and bug-fixing**
 
+* Reintroduce sanitize_carriers and sanitize_location to reduce the number of warnings related to components with undefined carriers `PR #1555 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1555>`__
+
 PyPSA-Earth 0.7.0
 =================
 
@@ -56,8 +58,6 @@ PyPSA-Earth 0.7.0
 * Add new hydrogen production technologies and reorganize existing structure `PR #1227 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1227>`__
 
 **Minor Changes and bug-fixing**
-
-* Reintroduce sanitize_carriers and sanitize_location to reduce the number of warnings related to components with undefined carriers `PR #1555 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1555>`__
 
 * Remove duplicates in environment file `PR #1473 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1473>`__
 

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -57,6 +57,8 @@ PyPSA-Earth 0.7.0
 
 **Minor Changes and bug-fixing**
 
+* Reintroduce sanitize_carriers and sanitize_location to reduce the number of warnings related to components with undefined carriers `PR #1555 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1555>`__
+
 * Remove duplicates in environment file `PR #1473 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1473>`__
 
 * Fix fallback logic for missing currency data by correctly applying the default exchange rate and build cache for storing commonly used exchange rates `PR #1492 <https://github.com/pypsa-meets-earth/pypsa-earth/pull/1492>`__

--- a/scripts/_helpers.py
+++ b/scripts/_helpers.py
@@ -1830,3 +1830,140 @@ def branch(condition, then, otherwise=None):
             return None
 
     return otherwise
+
+
+def rename_techs(label):
+    prefix_to_remove = [
+        "residential ",
+        "services ",
+        "urban ",
+        "rural ",
+        "central ",
+        "decentral ",
+    ]
+
+    rename_if_contains = [
+        "CHP",
+        "gas boiler",
+        "biogas",
+        "solar thermal",
+        "air heat pump",
+        "ground heat pump",
+        "resistive heater",
+        "Fischer-Tropsch",
+    ]
+
+    rename_if_contains_dict = {
+        "water tanks": "hot water storage",
+        "retrofitting": "building retrofitting",
+        "H2": "hydrogen storage",
+        "battery": "battery storage",
+        "CCS": "CCS",
+    }
+
+    rename = {
+        "solar": "solar PV",
+        "Sabatier": "methanation",
+        "offwind": "offshore wind",
+        "offwind-ac": "offshore wind (AC)",
+        "offwind-dc": "offshore wind (DC)",
+        "onwind": "onshore wind",
+        "ror": "hydroelectricity",
+        "hydro": "hydroelectricity",
+        "PHS": "hydroelectricity",
+        "co2 Store": "DAC",
+        "co2 stored": "CO2 sequestration",
+        "AC": "transmission lines",
+        "DC": "transmission lines",
+        "B2B": "transmission lines",
+    }
+
+    for ptr in prefix_to_remove:
+        if label[: len(ptr)] == ptr:
+            label = label[len(ptr) :]
+
+    for rif in rename_if_contains:
+        if rif in label:
+            label = rif
+
+    for old, new in rename_if_contains_dict.items():
+        if old in label:
+            label = new
+
+    for old, new in rename.items():
+        if old == label:
+            label = new
+    return label
+
+
+def add_missing_carriers(n, carriers):
+    """
+    Function to add missing carriers to the network without raising errors.
+    """
+    valid_carriers = {c for c in carriers if isinstance(c, str) and c.strip() != ""}
+    missing_carriers = valid_carriers - set(n.carriers.index)
+    if len(missing_carriers) > 0:
+        for carrier in missing_carriers:
+            n.add("Carrier", carrier)
+
+
+def sanitize_carriers(n, config):
+    """
+    Sanitize the carrier information in a PyPSA Network object.
+
+    The function ensures that all unique carrier names are present in the network's
+    carriers attribute, and adds nice names and colors for each carrier according
+    to the provided configuration dictionary.
+
+    Parameters
+    ----------
+    n : pypsa.Network
+        A PyPSA Network object that represents an electrical power system.
+    config : dict
+        A dictionary containing configuration information, specifically the
+        "plotting" key with "nice_names" and "tech_colors" keys for carriers.
+
+    Returns
+    -------
+    None
+        The function modifies the 'n' PyPSA Network object in-place, updating the
+        carriers attribute with nice names and colors.
+
+    Warnings
+    --------
+    Raises a warning if any carrier's "tech_colors" are not defined in the config dictionary.
+    """
+
+    for c in n.iterate_components():
+        if "carrier" in c.df:
+            add_missing_carriers(n, c.df.carrier)
+
+    carrier_i = n.carriers.index
+    nice_names = (
+        pd.Series(config["plotting"]["nice_names"])
+        .reindex(carrier_i)
+        .fillna(carrier_i.to_series())
+    )
+    n.carriers["nice_name"] = n.carriers.nice_name.where(
+        n.carriers.nice_name != "", nice_names
+    )
+
+    tech_colors = config["plotting"]["tech_colors"]
+    colors = pd.Series(tech_colors).reindex(carrier_i)
+    # try to fill missing colors with tech_colors after renaming
+    missing_colors_i = colors[colors.isna()].index
+    colors[missing_colors_i] = missing_colors_i.map(rename_techs).map(tech_colors)
+    if colors.isna().any():
+        missing_i = list(colors.index[colors.isna()])
+        logger.warning(f"tech_colors for carriers {missing_i} not defined in config.")
+    n.carriers["color"] = n.carriers.color.where(n.carriers.color != "", colors)
+
+
+def sanitize_locations(n):
+    if "location" in n.buses.columns:
+        n.buses["x"] = n.buses.x.where(n.buses.x != 0, n.buses.location.map(n.buses.x))
+        n.buses["y"] = n.buses.y.where(n.buses.y != 0, n.buses.location.map(n.buses.y))
+        n.buses["country"] = n.buses.country.where(
+            n.buses.country.ne("") & n.buses.country.notnull(),
+            n.buses.location.map(n.buses.country),
+        )

--- a/scripts/add_brownfield.py
+++ b/scripts/add_brownfield.py
@@ -12,9 +12,8 @@ import numpy as np
 import pandas as pd
 import pypsa
 import xarray as xr
-from add_existing_baseyear import add_build_year_to_new_assets
-
 from _helpers import sanitize_carriers, sanitize_locations
+from add_existing_baseyear import add_build_year_to_new_assets
 
 # from pypsa.clustering.spatial import normed_or_uniform
 

--- a/scripts/add_brownfield.py
+++ b/scripts/add_brownfield.py
@@ -14,6 +14,8 @@ import pypsa
 import xarray as xr
 from add_existing_baseyear import add_build_year_to_new_assets
 
+from _helpers import sanitize_carriers, sanitize_locations
+
 # from pypsa.clustering.spatial import normed_or_uniform
 
 logger = logging.getLogger(__name__)
@@ -258,6 +260,9 @@ if __name__ == "__main__":
     add_brownfield(n, n_p, year)
 
     disable_grid_expansion_if_limit_hit(n)
+
+    sanitize_carriers(n, snakemake.config)
+    sanitize_locations(n)
 
     n.meta = dict(snakemake.config, **dict(wildcards=dict(snakemake.wildcards)))
     n.export_to_netcdf(snakemake.output[0])

--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -102,6 +102,8 @@ from _helpers import (
     create_logger,
     read_csv_nafix,
     update_p_nom_max,
+    sanitize_carriers,
+    sanitize_locations,
 )
 from powerplantmatching.export import map_country_bus
 
@@ -919,6 +921,10 @@ if __name__ == "__main__":
             "Unexpected missing 'weight' column, which has been manually added. It may be due to missing generators."
         )
         n.generators["weight"] = pd.Series()
+
+    sanitize_carriers(n, snakemake.config)
+    if "location" in n.buses:
+        sanitize_locations(n)
 
     n.meta = snakemake.config
     n.export_to_netcdf(snakemake.output[0])

--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -101,9 +101,9 @@ from _helpers import (
     configure_logging,
     create_logger,
     read_csv_nafix,
-    update_p_nom_max,
     sanitize_carriers,
     sanitize_locations,
+    update_p_nom_max,
 )
 from powerplantmatching.export import map_country_bus
 

--- a/scripts/add_existing_baseyear.py
+++ b/scripts/add_existing_baseyear.py
@@ -17,6 +17,7 @@ import pandas as pd
 import powerplantmatching as pm
 import pypsa
 import xarray as xr
+from _helpers import sanitize_carriers, sanitize_locations
 
 # from _helpers import (
 #     configure_logging,
@@ -659,6 +660,7 @@ if __name__ == "__main__":
 
     n.meta = dict(snakemake.config, **dict(wildcards=dict(snakemake.wildcards)))
 
-    # sanitize_carriers(n, snakemake.config)
+    sanitize_carriers(n, snakemake.config)
+    sanitize_locations(n)
 
     n.export_to_netcdf(snakemake.output[0])

--- a/scripts/plot_network.py
+++ b/scripts/plot_network.py
@@ -32,6 +32,7 @@ from _helpers import (
     configure_logging,
     create_logger,
     load_network_for_plots,
+    rename_techs,
 )
 from matplotlib.legend_handler import HandlerPatch
 from matplotlib.patches import Circle, Ellipse
@@ -778,70 +779,6 @@ preferred_order = pd.Index(
         "CO2 sequestration",
     ]
 )
-
-
-def rename_techs(label):
-    prefix_to_remove = [
-        "residential ",
-        "services ",
-        "urban ",
-        "rural ",
-        "central ",
-        "decentral ",
-    ]
-
-    rename_if_contains = [
-        "CHP",
-        "gas boiler",
-        "biogas",
-        "solar thermal",
-        "air heat pump",
-        "ground heat pump",
-        "resistive heater",
-        "Fischer-Tropsch",
-    ]
-
-    rename_if_contains_dict = {
-        "water tanks": "hot water storage",
-        "retrofitting": "building retrofitting",
-        "H2": "hydrogen storage",
-        "battery": "battery storage",
-        "CCS": "CCS",
-    }
-
-    rename = {
-        "solar": "solar PV",
-        "Sabatier": "methanation",
-        "offwind": "offshore wind",
-        "offwind-ac": "offshore wind (AC)",
-        "offwind-dc": "offshore wind (DC)",
-        "onwind": "onshore wind",
-        "ror": "hydroelectricity",
-        "hydro": "hydroelectricity",
-        "PHS": "hydroelectricity",
-        "co2 Store": "DAC",
-        "co2 stored": "CO2 sequestration",
-        "AC": "transmission lines",
-        "DC": "transmission lines",
-        "B2B": "transmission lines",
-    }
-
-    for ptr in prefix_to_remove:
-        if label[: len(ptr)] == ptr:
-            label = label[len(ptr) :]
-
-    for rif in rename_if_contains:
-        if rif in label:
-            label = rif
-
-    for old, new in rename_if_contains_dict.items():
-        if old in label:
-            label = new
-
-    for old, new in rename.items():
-        if old == label:
-            label = new
-    return label
 
 
 def rename_techs_tyndp(tech):

--- a/scripts/prepare_network.py
+++ b/scripts/prepare_network.py
@@ -66,9 +66,9 @@ import pandas as pd
 import pypsa
 import requests
 from _helpers import (
-    BASE_DIR, 
-    configure_logging, 
-    create_logger, 
+    BASE_DIR,
+    configure_logging,
+    create_logger,
     sanitize_carriers,
     sanitize_locations,
 )

--- a/scripts/prepare_network.py
+++ b/scripts/prepare_network.py
@@ -65,7 +65,13 @@ import numpy as np
 import pandas as pd
 import pypsa
 import requests
-from _helpers import BASE_DIR, configure_logging, create_logger
+from _helpers import (
+    BASE_DIR, 
+    configure_logging, 
+    create_logger, 
+    sanitize_carriers,
+    sanitize_locations,
+)
 from add_electricity import load_costs, update_transmission_costs
 
 idx = pd.IndexSlice
@@ -437,6 +443,9 @@ if __name__ == "__main__":
         enforce_autarky(n)
     elif "ATKc" in opts:
         enforce_autarky(n, only_crossborder=True)
+
+    sanitize_carriers(n, snakemake.config)
+    sanitize_locations(n)
 
     n.meta = dict(snakemake.config, **dict(wildcards=dict(snakemake.wildcards)))
     n.export_to_netcdf(snakemake.output[0])

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -25,10 +25,10 @@ from _helpers import (
     override_component_attrs,
     prepare_costs,
     safe_divide,
-    three_2_two_digits_country,
-    two_2_three_digits_country,
     sanitize_carriers,
     sanitize_locations,
+    three_2_two_digits_country,
+    two_2_three_digits_country,
 )
 from prepare_transport_data import prepare_transport_data
 

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -27,6 +27,8 @@ from _helpers import (
     safe_divide,
     three_2_two_digits_country,
     two_2_three_digits_country,
+    sanitize_carriers,
+    sanitize_locations,
 )
 from prepare_transport_data import prepare_transport_data
 
@@ -3278,6 +3280,9 @@ if __name__ == "__main__":
 
     if snakemake.params.water_costs:
         add_custom_water_cost(n)
+
+    sanitize_carriers(n, snakemake.config)
+    sanitize_locations(n)
 
     n.export_to_netcdf(snakemake.output[0])
 


### PR DESCRIPTION
## Changes proposed in this Pull Request

**This is a fast track merge request for PyPSA-ASEAN**

This pull request reduces the number of warnings related to components with undefined carriers. While this feature was already present in pypsa-eur-sec, it had not yet been fully implemented in pypsa-earth.

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
